### PR TITLE
Fix errorness Singularity version 2.5.1

### DIFF
--- a/conf/cfc.config
+++ b/conf/cfc.config
@@ -14,7 +14,7 @@ singularity {
 */
 
 process {
-    beforeScript = 'module load qbic/singularity_slurm/2.5.1'
+    beforeScript = 'module load qbic/singularity_slurm/2.5.2'
     executor = 'slurm'
 }
 


### PR DESCRIPTION
This version is known to make issues when trying to bootstrap a image from a Dockerfile or Docker Hub: https://github.com/singularityware/singularity/issues/1649