### PR TITLE
Get MultiQC to save plots as stand alone files in directory multiqc_plots (standard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 1.4dev
 
 #### Pipeline updates
-* get MultiQC to save plots as stand alone files
+* Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
 
 ## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) - 2019-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Pipeline updates
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183): added the folder "multiqc_plots" to the output.
+* Get MultiQC to write out the software versions in a .csv file [#185] (https://github.com/nf-core/rnaseq/issues/185)
 
 ## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) - 2019-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Pipeline updates
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
+* Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183): added the folder "multiqc_plots" to the output.
 
 ## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) - 2019-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # nf-core/rnaseq: Changelog
 
+## Version 1.4dev
+
+#### Pipeline updates
+* get MultiQC to save plots as stand alone files
+
 ## Version 1.3
 
 #### Pipeline Updates

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -24,3 +24,5 @@ report_section_order:
 table_columns_visible:
     FastQC:
         percent_duplicates: False
+
+export_plots: true

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 from collections import OrderedDict
 import re
+import csv
 
 regexes = {
     'nf-core/rnaseq': ['v_ngi_rnaseq.txt', r"(\S+)"],
@@ -63,3 +64,9 @@ data: |
 for k,v in results.items():
     print("        <dt>{}</dt><dd><samp>{}</samp></dd>".format(k,v))
 print ("    </dl>")
+
+# Write out regexes.items() as csv file: 
+with open('software_versions.csv', 'wb') as f:
+    w = csv.DictWriter(f, regexes.items().keys())
+    w.writeheader()
+    w.writerow(regexes.items())

--- a/main.nf
+++ b/main.nf
@@ -1095,6 +1095,7 @@ process multiqc {
     output:
     file "*multiqc_report.html" into multiqc_report
     file "*_data"
+    file "multiqc_plots/*"
 
     script:
     rtitle = custom_runName ? "--title \"$custom_runName\"" : ''

--- a/main.nf
+++ b/main.nf
@@ -1096,6 +1096,7 @@ process multiqc {
     file "*multiqc_report.html" into multiqc_report
     file "*_data"
     file "multiqc_plots/*"
+    file "software_versions.csv"
 
     script:
     rtitle = custom_runName ? "--title \"$custom_runName\"" : ''


### PR DESCRIPTION
This pull request is the prosecution of [#184](https://github.com/nf-core/rnaseq/pull/184): here the folder "multiqc_plots", in which MultiQC stores the plots, is added to the output.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
