### PR TITLE
Add param to use `--nextseq` option in trim_galore [WIP]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ LABEL authors="phil.ewels@scilifelab.se" \
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/nf-core-rnaseq-1.3/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-rnaseq-1.31/bin:$PATH

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,13 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-rnaseq-1.3
+name: nf-core-rnaseq-1.31
 channels:
   - conda-forge
   - bioconda
   - defaults
 dependencies:
   - fastqc=0.11.8
-  - trim-galore=0.5.0
+  - trim-galore=0.6.2
   - star=2.6.1d # don't upgrade me - 2.7X indices incompatible with iGenomes.
   - hisat2=2.1.0
   - picard=2.18.27

--- a/main.nf
+++ b/main.nf
@@ -524,11 +524,11 @@ process trim_galore {
     nextseq = trim_nextseq > 0 ? "--nextseq ${trim_nextseq}" : ''
     if (params.singleEnd) {
         """
-        trim_galore --fastqc --gzip $c_r1 $tpc_r1 $q_nextseq $reads
+        trim_galore --fastqc --gzip $c_r1 $tpc_r1 $nextseq $reads
         """
     } else {
         """
-        trim_galore --paired --fastqc --gzip $c_r1 $c_r2 $tpc_r1 $tpc_r2 $q_nextseq $reads
+        trim_galore --paired --fastqc --gzip $c_r1 $c_r2 $tpc_r1 $tpc_r2 $nextseq $reads
         """
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -47,7 +47,8 @@ def helpMessage() {
       --clip_r1 [int]               Instructs Trim Galore to remove bp from the 5' end of read 1 (or single-end reads)
       --clip_r2 [int]               Instructs Trim Galore to remove bp from the 5' end of read 2 (paired-end reads only)
       --three_prime_clip_r1 [int]   Instructs Trim Galore to remove bp from the 3' end of read 1 AFTER adapter/quality trimming has been performed
-      --three_prime_clip_r2 [int]   Instructs Trim Galore to re move bp from the 3' end of read 2 AFTER adapter/quality trimming has been performed
+      --three_prime_clip_r2 [int]   Instructs Trim Galore to remove bp from the 3' end of read 2 AFTER adapter/quality trimming has been performed
+      --trim_nextseq [int]          Instructs Trim Galore to apply the --nextseq-trim=X option, to trim based on quality after removing poly-G tails
 
     Presets:
       --pico                        Sets trimming and standedness settings for the SMARTer Stranded Total RNA-Seq Kit - Pico Input kit. Equivalent to: --forward_stranded --clip_r1 3 --three_prime_clip_r2 3
@@ -119,6 +120,7 @@ three_prime_clip_r2 = params.three_prime_clip_r2
 forward_stranded = params.forward_stranded
 reverse_stranded = params.reverse_stranded
 unstranded = params.unstranded
+trim_nextseq = params.trim_nextseq
 
 // Preset trimming options
 if (params.pico){
@@ -519,13 +521,14 @@ process trim_galore {
     c_r2 = clip_r2 > 0 ? "--clip_r2 ${clip_r2}" : ''
     tpc_r1 = three_prime_clip_r1 > 0 ? "--three_prime_clip_r1 ${three_prime_clip_r1}" : ''
     tpc_r2 = three_prime_clip_r2 > 0 ? "--three_prime_clip_r2 ${three_prime_clip_r2}" : ''
+    q_nextseq = trim_nextseq > 0 ? "--nextseq-trim ${trim_nextseq}" : ''
     if (params.singleEnd) {
         """
-        trim_galore --fastqc --gzip $c_r1 $tpc_r1 $reads
+        trim_galore --fastqc --gzip $c_r1 $tpc_r1 $q_nextseq $reads
         """
     } else {
         """
-        trim_galore --paired --fastqc --gzip $c_r1 $c_r2 $tpc_r1 $tpc_r2 $reads
+        trim_galore --paired --fastqc --gzip $c_r1 $c_r2 $tpc_r1 $tpc_r2 $q_nextseq $reads
         """
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -48,7 +48,7 @@ def helpMessage() {
       --clip_r2 [int]               Instructs Trim Galore to remove bp from the 5' end of read 2 (paired-end reads only)
       --three_prime_clip_r1 [int]   Instructs Trim Galore to remove bp from the 3' end of read 1 AFTER adapter/quality trimming has been performed
       --three_prime_clip_r2 [int]   Instructs Trim Galore to remove bp from the 3' end of read 2 AFTER adapter/quality trimming has been performed
-      --trim_nextseq [int]          Instructs Trim Galore to apply the --nextseq-trim=X option, to trim based on quality after removing poly-G tails
+      --trim_nextseq [int]          Instructs Trim Galore to apply the --nextseq=X option, to trim based on quality after removing poly-G tails
 
     Presets:
       --pico                        Sets trimming and standedness settings for the SMARTer Stranded Total RNA-Seq Kit - Pico Input kit. Equivalent to: --forward_stranded --clip_r1 3 --three_prime_clip_r2 3
@@ -521,7 +521,7 @@ process trim_galore {
     c_r2 = clip_r2 > 0 ? "--clip_r2 ${clip_r2}" : ''
     tpc_r1 = three_prime_clip_r1 > 0 ? "--three_prime_clip_r1 ${three_prime_clip_r1}" : ''
     tpc_r2 = three_prime_clip_r2 > 0 ? "--three_prime_clip_r2 ${three_prime_clip_r2}" : ''
-    q_nextseq = trim_nextseq > 0 ? "--nextseq-trim ${trim_nextseq}" : ''
+    nextseq = trim_nextseq > 0 ? "--nextseq ${trim_nextseq}" : ''
     if (params.singleEnd) {
         """
         trim_galore --fastqc --gzip $c_r1 $tpc_r1 $q_nextseq $reads

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,6 +42,7 @@ params {
   clip_r2 = 0
   three_prime_clip_r1 = 0
   three_prime_clip_r2 = 0
+  trim_nextseq = 0
 
   // Defaults
   sampleLevel = false


### PR DESCRIPTION
This is a PR to add a `--trim-nextseq` option, which exposes the `--nextseq [int]` option in trim_galore.

## changes 

- add `--trim-nextseq [int]` option to nextflow
- update `trim_galore` to the latest version (necessary for this option)
- increment the version number for the conda env (wasn't sure if this was necessary, but it kept my environment clean)
- update the docker file according to the version increment.

Note: 

- I did not change the `json` file which lists the parameters, nor did I change docs/readme/etc.
- I did not run any tests on the new docker, except to use this option in a specific project.
- I did not add additional tests
- I do not have access to a test dataset for this option

I will update this PR as I get to these things.

## Rationale

This is used when trimming reads from 2-color (typically nextseq) sequencers since they cannot distinguish between no-call (ie poor quality) and a G, leading to poly-G tails on reads that should be trimmed before reads are filtered based on phred scores. This issue is described best [on qcfail](https://sequencing.qcfail.com/articles/illumina-2-colour-chemistry-can-overcall-high-confidence-g-bases/). 

In order to support this, I had to update the version of trim_galore in the environment.yml file.

## PR checklist

 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
